### PR TITLE
Filter collated ROM folders by available pak

### DIFF
--- a/workspace/all/unuos/unuos.c
+++ b/workspace/all/unuos/unuos.c
@@ -957,6 +957,7 @@ static Array* getEntries(char* path){
 			while((dp = readdir(dh)) != NULL) {
 				if (hide(dp->d_name)) continue;
 				if (dp->d_type!=DT_DIR) continue;
+				if (!hasRoms(dp->d_name)) continue;
 				strcpy(tmp, dp->d_name);
 			
 				if (!prefixMatch(collated_path, full_path)) continue;


### PR DESCRIPTION
## Summary
- skip collated ROM folders that do not have a matching emulator pak
- keeps combined folders from showing games that cannot launch through an available pak

## Test
- git diff --check
- ./workspace/linux/build-unuos.sh