### PR TITLE
Avoid timezone shift when restoring saved time

### DIFF
--- a/skeleton/SYSTEM/gkdpixel/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/gkdpixel/paks/MinUI.pak/launch.sh
@@ -36,8 +36,6 @@ keymon.elf &
 if [ -f "$DATETIME_PATH" ]; then
 	DATETIME=`cat "$DATETIME_PATH"`
 	date +'%F %T' -s "$DATETIME"
-	DATETIME=`date +'%s'`
-	date -u -s "@$DATETIME"
 fi
 
 #######################################

--- a/skeleton/SYSTEM/m17/paks/MinUI.pak/launch.sh
+++ b/skeleton/SYSTEM/m17/paks/MinUI.pak/launch.sh
@@ -37,8 +37,6 @@ keymon.elf &
 if [ -f "$DATETIME_PATH" ]; then
 	DATETIME=`cat "$DATETIME_PATH"`
 	date +'%F %T' -s "$DATETIME"
-	DATETIME=`date +'%s'`
-	date -u -s "@$DATETIME"
 fi
 
 #######################################

--- a/skeleton/SYSTEM/miyoomini/paks/UnuOS.pak/launch.sh
+++ b/skeleton/SYSTEM/miyoomini/paks/UnuOS.pak/launch.sh
@@ -107,8 +107,6 @@ keymon.elf & # &> /mnt/SDCARD/keymon.txt &
 if [ -f "$DATETIME_PATH" ] && [ ! -f "$USERDATA_PATH/enable-rtc" ]; then
 	DATETIME=`cat "$DATETIME_PATH"`
 	date +'%F %T' -s "$DATETIME"
-	DATETIME=`date +'%s'`
-	date -u -s "@$DATETIME"
 fi
 
 #######################################

--- a/skeleton/SYSTEM/trimuismart/paks/UnuOS.pak/launch.sh
+++ b/skeleton/SYSTEM/trimuismart/paks/UnuOS.pak/launch.sh
@@ -56,8 +56,6 @@ keymon.elf &
 if [ -f "$DATETIME_PATH" ]; then
 	DATETIME=`cat "$DATETIME_PATH"`
 	date +'%F %T' -s "$DATETIME"
-	DATETIME=`date +'%s'`
-	date -u -s "@$DATETIME"
 fi
 
 #######################################


### PR DESCRIPTION
## Summary
- restore saved datetime.txt values directly with date -s
- remove the extra epoch-to-UTC conversion that can offset restored time by the timezone

## Test
- git diff --check
- ./workspace/linux/build-unuos.sh