### PR TITLE
Clarify device shortcut documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Japanese UI:
 - [Collections](https://github.com/retronian/UnuOS/wiki/Collections) (custom ROM groupings across consoles)
 - [Game Focus Mode](https://github.com/retronian/UnuOS/wiki/Game-Focus-Mode) for showing only selected games
 - [In-app screenshot](https://github.com/retronian/UnuOS/wiki/Screenshots) (SELECT+START)
-- Auto sleep after 30 seconds; hold POWER to sleep / wake
+- Auto sleep after 30 seconds; manual sleep / wake shortcut depends on device
 - Resumes from the previous running state on power on
 
 ## Additions from MinUI

--- a/skeleton/BASE/README.txt
+++ b/skeleton/BASE/README.txt
@@ -109,25 +109,27 @@ For devices without a dedicated MENU button
 	RGB30: use L3 or R3 for MENU
 	M17:   use + or - for MENU
 
-RGB30 / MIYOO MINI PLUS / RG35XX (PLUS) / TRIMUI SMART PRO / TRIMUI BRICK / GKD PIXEL / MIYOO A30 / MAGICX XU MINI M / MIYOO FLIP / MAGICX MINI ZERO 28
-
-  Brightness: MENU + VOLUME UP
-                  or VOLUME DOWN
-
-MIYOO MINI / TRIMUI SMART / M17
+MIYOO MINI
 
   Volume: SELECT + L or R
   Brightness: START + L or R
-
-RGB30 / MIYOO MINI (PLUS) / RG35XX (PLUS) / TRIMUI SMART PRO / TRIMUI BRICK / GKD PIXEL / MIYOO A30 / MAGICX XU MINI M / MIYOO FLIP / MAGICX MINI ZERO 28
-
   Sleep: POWER
   Wake: POWER
 
 TRIMUI SMART / M17
 
+  Volume: SELECT + L or R
+  Brightness: START + L or R
   Sleep: MENU (twice)
   Wake: MENU
+
+RGB30 / MIYOO MINI PLUS / RG35XX (PLUS) / TRIMUI SMART PRO / TRIMUI BRICK / GKD PIXEL / MIYOO A30 / MAGICX XU MINI M / MIYOO FLIP / MAGICX MINI ZERO 28
+
+  Volume: hardware volume buttons
+  Brightness: MENU + VOLUME UP
+                  or VOLUME DOWN
+  Sleep: POWER
+  Wake: POWER
 
 TRIMUI SMART PRO / TRIMUI BRICK
 


### PR DESCRIPTION
## Summary
- reorganize packaged shortcut docs by device group
- avoid implying every device uses POWER for manual sleep/wake

## Verification
- ran README formatting path with workspace/all/readmes makefile
- ran git diff --check