### PR TITLE
Add fetch target for external sources

### DIFF
--- a/makefile
+++ b/makefile
@@ -25,7 +25,7 @@ RELEASE_NAME=$(RELEASE_BASE)-$(RELEASE_DOT)
 
 ###########################################################
 
-.PHONY: build
+.PHONY: build fetch
 
 export MAKEFLAGS=--no-print-directory
 
@@ -41,6 +41,10 @@ build:
 	# ----------------------------------------------------
 	make build -f makefile.toolchain PLATFORM=$(PLATFORM)
 	# ----------------------------------------------------
+
+fetch:
+	for PLATFORM in $(PLATFORMS); do make -f makefile.toolchain PLATFORM=$$PLATFORM fetch; done
+	for PLATFORM in $(PLATFORMS); do make -C workspace PLATFORM=$$PLATFORM fetch; done
 
 system:
 	make -f ./workspace/$(PLATFORM)/platform/makefile.copy PLATFORM=$(PLATFORM)

--- a/makefile.toolchain
+++ b/makefile.toolchain
@@ -1,6 +1,6 @@
 # there is no reason to use this makefile manually
 
-.PHONY: build
+.PHONY: build fetch
 
 ifeq (,$(PLATFORM))
 $(error please specify PLATFORM, eg. make PLATFORM=trimui)
@@ -21,6 +21,8 @@ $(INIT_IF_NECESSARY): $(GIT_IF_NECESSARY)
 $(GIT_IF_NECESSARY):
 	mkdir -p toolchains
 	git clone https://github.com/shauninman/union-$(PLATFORM)-toolchain/ toolchains/$(PLATFORM)-toolchain
+
+fetch: $(GIT_IF_NECESSARY)
 
 clean:
 	cd toolchains/$(PLATFORM)-toolchain && make clean

--- a/workspace/all/cores/makefile
+++ b/workspace/all/cores/makefile
@@ -5,7 +5,7 @@ PLATFORM=$(UNION_PLATFORM)
 endif
 
 ifeq (,$(PLATFORM))
-	$(error please specify PLATFORM, eg. PLATFORM=trimui make)
+$(error please specify PLATFORM, eg. PLATFORM=trimui make)
 endif
 
 ###############################
@@ -25,6 +25,8 @@ PROCS = -j4
 ###############################
 
 BUILD_ROOT=../../$(PLATFORM)/cores
+
+.PHONY: fetch
 
 define TEMPLATE=
 
@@ -71,6 +73,8 @@ all: cores
 $(foreach CORE,$(CORES),$(eval $(call TEMPLATE,$(CORE))))
 
 cores: $(foreach CORE,$(CORES),$(CORE))
+
+fetch: $(foreach CORE,$(CORES),clone-$(CORE))
 	
 clean: $(foreach CORE,$(CORES),clean-$(CORE))
 	

--- a/workspace/all/minarch/makefile
+++ b/workspace/all/minarch/makefile
@@ -8,8 +8,10 @@ ifeq (,$(PLATFORM))
 	$(error please specify PLATFORM, eg. PLATFORM=trimui make)
 endif
 
+ifeq (,$(filter fetch,$(MAKECMDGOALS)))
 ifeq (,$(CROSS_COMPILE))
-	$(error missing CROSS_COMPILE for this toolchain)
+$(error missing CROSS_COMPILE for this toolchain)
+endif
 endif
 
 ###########################################################
@@ -40,9 +42,14 @@ CFLAGS += -DBUILD_DATE=\"${BUILD_DATE}\" -DBUILD_HASH=\"${BUILD_HASH}\"
 
 PRODUCT= build/$(PLATFORM)/$(TARGET).elf
 
+.PHONY: fetch
+
 all: libretro-common $(PREFIX)/include/msettings.h
 	mkdir -p build/$(PLATFORM)
 	$(CC) $(SOURCE) -o $(PRODUCT) $(CFLAGS) $(LDFLAGS)
+
+fetch: libretro-common
+
 clean:
 	rm -f $(PRODUCT)
 

--- a/workspace/gkdpixel/makefile
+++ b/workspace/gkdpixel/makefile
@@ -10,9 +10,13 @@ endif
 
 ###########################################################
 
+.PHONY: fetch
+
 all: readmes
 
 early:
+
+fetch:
 
 clean:
 	

--- a/workspace/m17/makefile
+++ b/workspace/m17/makefile
@@ -10,11 +10,15 @@ endif
 
 ###########################################################
 
+.PHONY: fetch
+
 all: readmes
 	cd ./boot && ./build.sh
 
 early: 
 	# early
+
+fetch:
 
 clean:
 	cd ./overclock && make clean

--- a/workspace/magicmini/makefile
+++ b/workspace/magicmini/makefile
@@ -13,12 +13,17 @@ endif
 ###########################################################
 
 REQUIRES_351FILES=other/351files
+FETCH_DEPS=$(REQUIRES_351FILES)
+
+.PHONY: fetch
 
 all: readmes
 	
-early: $(REQUIRES_351FILES)
+early: $(FETCH_DEPS)
 	mkdir -p other
 	cd $(REQUIRES_351FILES) && make clean && START_PATH=/storage/TF2 CXX=${CROSS_COMPILE}g++ make
+
+fetch: $(FETCH_DEPS)
 	
 clean:
 	cd $(REQUIRES_351FILES) && make clean

--- a/workspace/makefile
+++ b/workspace/makefile
@@ -12,7 +12,7 @@ endif
 
 ###########################################################
 
-.PHONY: all
+.PHONY: all fetch
 
 all:
 	cd ./$(PLATFORM)/libmsettings && make
@@ -26,6 +26,11 @@ all:
 	cd ./all/say/ && make
 	cd ./$(PLATFORM)/cores && make
 	cd ./$(PLATFORM) && make
+
+fetch:
+	cd ./$(PLATFORM) && make fetch
+	cd ./all/minarch && make fetch
+	cd ./$(PLATFORM)/cores && make fetch
 
 clean:
 	cd ./$(PLATFORM)/libmsettings && make clean

--- a/workspace/miyoomini/makefile
+++ b/workspace/miyoomini/makefile
@@ -12,6 +12,9 @@ endif
 
 REQUIRES_SDL=other/sdl
 REQUIRES_COMMANDER=other/DinguxCommander
+FETCH_DEPS=$(REQUIRES_SDL) $(REQUIRES_COMMANDER)
+
+.PHONY: fetch
 
 all: readmes
 	cd blank && make
@@ -20,11 +23,13 @@ all: readmes
 	cd show && make
 	cd overclock && make
 
-early: $(REQUIRES_SDL) $(REQUIRES_COMMANDER)
+early: $(FETCH_DEPS)
 	cd other/sdl && ./make.sh
 	cd other/logotweak && make
 	cd other/latency_reduction && make
 	cd other/DinguxCommander && make -j
+
+fetch: $(FETCH_DEPS)
 
 clean:
 	cd blank && make clean

--- a/workspace/my282/cores/makefile
+++ b/workspace/my282/cores/makefile
@@ -1,4 +1,8 @@
+.PHONY: fetch
+
 all:
 	# copy from original rg35xx (for now?)
 	rm -rf output
 	cp -r ../../rg35xx/cores/output ./
+
+fetch:

--- a/workspace/my282/makefile
+++ b/workspace/my282/makefile
@@ -14,17 +14,22 @@ endif
 
 REQUIRES_COMMANDER=other/DinguxCommander-sdl2
 REQUIRES_UNZIP60=other/unzip60
+FETCH_DEPS=$(REQUIRES_COMMANDER) $(REQUIRES_UNZIP60)
+
+.PHONY: fetch
 
 all: readmes
 	cd show && make
 	cd overclock && make
 	cd other/squashfs && make
 
-early: $(REQUIRES_COMMANDER) $(REQUIRES_UNZIP60)
+early: $(FETCH_DEPS)
 	mkdir -p other
 	cd $(REQUIRES_COMMANDER) && make -j
 	cd $(REQUIRES_UNZIP60) && make -f unix/Makefile.trimuismart unzip
 	cd libmstick && make
+
+fetch: $(FETCH_DEPS)
 	
 clean:
 	cd show && make clean

--- a/workspace/my355/makefile
+++ b/workspace/my355/makefile
@@ -16,17 +16,22 @@ REQUIRES_EVTEST=other/evtest
 REQUIRES_MKBOOTIMG=other/mkbootimg
 REQUIRES_RSCEGO=other/rsce-go
 REQUIRES_COMMANDER=other/DinguxCommander-sdl2
+FETCH_DEPS=$(REQUIRES_EVTEST) $(REQUIRES_MKBOOTIMG) $(REQUIRES_RSCEGO) $(REQUIRES_COMMANDER)
+
+.PHONY: fetch
 
 all: readmes
 	cd show && make
 	cd other/squashfs && make
 
-early: $(REQUIRES_EVTEST) $(REQUIRES_MKBOOTIMG) $(REQUIRES_RSCEGO) $(REQUIRES_COMMANDER)
+early: $(FETCH_DEPS)
 	mkdir -p other
 	cd $(REQUIRES_COMMANDER) && make -j
 	cd $(REQUIRES_EVTEST) && $(CROSS_COMPILE)gcc -o evtest evtest.c
 	cd $(REQUIRES_MKBOOTIMG) && make
 	cd $(REQUIRES_RSCEGO) && go build -o rsce_tool
+
+fetch: $(FETCH_DEPS)
 	
 clean:
 	cd show && make clean

--- a/workspace/rg35xx/makefile
+++ b/workspace/rg35xx/makefile
@@ -13,13 +13,18 @@ endif
 ###########################################################
 
 REQUIRES_COMMANDER=other/DinguxCommander
+FETCH_DEPS=$(REQUIRES_COMMANDER)
+
+.PHONY: fetch
 
 all: readmes
 	cd ./overclock && make
 	cd ./boot && ./build.sh
 
-early: $(REQUIRES_COMMANDER)
+early: $(FETCH_DEPS)
 	cd other/DinguxCommander && make -j
+
+fetch: $(FETCH_DEPS)
 
 clean:
 	cd ./overclock && make clean

--- a/workspace/rg35xxplus/cores/makefile
+++ b/workspace/rg35xxplus/cores/makefile
@@ -1,4 +1,8 @@
+.PHONY: fetch
+
 all:
 	# copy from original rg35xx (for now?)
 	rm -rf output
 	cp -r ../../rg35xx/cores/output ./
+
+fetch:

--- a/workspace/rg35xxplus/makefile
+++ b/workspace/rg35xxplus/makefile
@@ -16,13 +16,16 @@ REQUIRES_UNZIP60=other/unzip60
 REQUIRES_SDL2=other/sdl2
 REQUIRES_DTC=other/dtc
 REQUIRES_FBSET=other/fbset
+FETCH_DEPS=$(REQUIRES_UNZIP60) $(REQUIRES_SDL2) $(REQUIRES_DTC) $(REQUIRES_FBSET)
+
+.PHONY: fetch
 
 all: readmes
 	cd boot && ./build.sh
 	cd init && make
 	cd show && make
 
-early: $(REQUIRES_UNZIP60) $(REQUIRES_SDL2) $(REQUIRES_DTC) $(REQUIRES_FBSET)
+early: $(FETCH_DEPS)
 	mkdir -p other
 	cd $(REQUIRES_DTC) && CC=${CROSS_COMPILE}gcc make NO_PYTHON=1 EXTRA_CFLAGS="-Wno-error=sign-compare" dtc
 	cd $(REQUIRES_UNZIP60) && make -f unix/Makefile.trimuismart unzip
@@ -61,6 +64,8 @@ early: $(REQUIRES_UNZIP60) $(REQUIRES_SDL2) $(REQUIRES_DTC) $(REQUIRES_FBSET)
 	# copy libs from toolchain (later moved to build)
 	cp $(PREFIX)/lib/libSDL2_image-2.0.so.0.0.1 ../libSDL2_image-2.0.so.0
 	cp $(PREFIX)/lib/libSDL2_ttf-2.0.so.0.14.0 ../libSDL2_ttf-2.0.so.0
+
+fetch: $(FETCH_DEPS)
 	
 clean:
 	cd boot && rm -rf output

--- a/workspace/rgb30/makefile
+++ b/workspace/rgb30/makefile
@@ -12,6 +12,9 @@ endif
 
 REQUIRES_COMMANDER=other/DinguxCommander
 REQUIRES_SDLCOMPAT=other/sdl12-compat
+FETCH_DEPS=$(REQUIRES_COMMANDER) $(REQUIRES_SDLCOMPAT)
+
+.PHONY: fetch
 
 all: readmes
 	cd show && make
@@ -19,6 +22,8 @@ all: readmes
 early: $(REQUIRES_COMMANDER) $(REQUIRES_SDLCOMPAT)/build
 	cd $(REQUIRES_COMMANDER) && make -j
 	cd $(REQUIRES_SDLCOMPAT) && cmake --build build
+
+fetch: $(FETCH_DEPS)
 
 clean:
 	cd $(REQUIRES_COMMANDER) && make clean

--- a/workspace/tg5040/makefile
+++ b/workspace/tg5040/makefile
@@ -14,16 +14,21 @@ REQUIRES_EVTEST=other/evtest
 REQUIRES_JSTEST=other/jstest
 REQUIRES_UNZIP60=other/unzip60
 REQUIRES_COMMANDER=other/DinguxCommander-sdl2
+FETCH_DEPS=$(REQUIRES_EVTEST) $(REQUIRES_JSTEST) $(REQUIRES_UNZIP60) $(REQUIRES_COMMANDER)
+
+.PHONY: fetch
 
 all: readmes
 	cd show && make
 
-early: $(REQUIRES_EVTEST) $(REQUIRES_JSTEST) $(REQUIRES_UNZIP60) $(REQUIRES_COMMANDER)
+early: $(FETCH_DEPS)
 	mkdir -p other
 	cd $(REQUIRES_COMMANDER) && make -j
 	cd $(REQUIRES_EVTEST) && $(CROSS_COMPILE)gcc -o evtest evtest.c
 	cd $(REQUIRES_JSTEST) && $(CROSS_COMPILE)gcc -o jstest jstest.c
 	cd $(REQUIRES_UNZIP60) && make -f unix/Makefile.trimuismart unzip
+
+fetch: $(FETCH_DEPS)
 
 clean:
 	cd show && make clean

--- a/workspace/trimuismart/makefile
+++ b/workspace/trimuismart/makefile
@@ -12,14 +12,19 @@ endif
 
 REQUIRES_COMMANDER=other/DinguxCommander
 REQUIRES_UNZIP60=other/unzip60
+FETCH_DEPS=$(REQUIRES_COMMANDER) $(REQUIRES_UNZIP60)
+
+.PHONY: fetch
 
 all: readmes
 	cd show && make
 
-early: $(REQUIRES_COMMANDER) $(REQUIRES_UNZIP60)
+early: $(FETCH_DEPS)
 	mkdir -p other
 	cd other/DinguxCommander && make -j
 	cd other/unzip60 && make -f unix/Makefile.trimuismart unzip
+
+fetch: $(FETCH_DEPS)
 
 clean:
 	cd show && make clean

--- a/workspace/zero28/cores/makefile
+++ b/workspace/zero28/cores/makefile
@@ -1,4 +1,8 @@
+.PHONY: fetch
+
 all:
 	# copy from trimui smart pro (for now?)
 	rm -rf output
 	cp -r ../../tg5040/cores/output ./
+
+fetch:

--- a/workspace/zero28/makefile
+++ b/workspace/zero28/makefile
@@ -13,14 +13,19 @@ endif
 ###########################################################
 
 REQUIRES_COMMANDER=other/DinguxCommander-sdl2
+FETCH_DEPS=$(REQUIRES_COMMANDER)
+
+.PHONY: fetch
 
 all: readmes
 	cd bl && make
 	cd show && make
 
-early: $(REQUIRES_COMMANDER)
+early: $(FETCH_DEPS)
 	mkdir -p other
 	cd $(REQUIRES_COMMANDER) && make -j
+
+fetch: $(FETCH_DEPS)
 		
 clean:
 	cd bl && make clean


### PR DESCRIPTION
## Summary
- add a top-level make fetch target that fetches toolchains and workspace sources
- add fetch targets for platform helper repos, minarch libretro-common, and core repos
- keep fetch limited to source retrieval where possible, avoiding platform builds/configure steps

## Verification
- make -n fetch PLATFORMS=miyoomini
- make -C workspace PLATFORM=miyoomini -n fetch
- make -C workspace/miyoomini/cores PLATFORM=miyoomini -n fetch
- make -C workspace/all/minarch PLATFORM=miyoomini -n fetch
- make -C workspace PLATFORM=<each platform> -n fetch
- git diff --check