### PR TITLE
Document Bootlogo tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ UnuOS is a fork of [MinUI](https://github.com/shauninman/MinUI). The following a
 - **Game Focus Mode.** Create `Collections/Only.txt` on the SD card to show only the games listed in that collection. Settings, Tools, Collections, Recently Played, and system folders are hidden while the file exists.
 - **Native in-app screenshot.** Hold SELECT + press START anywhere in the launcher or during gameplay to write `Screenshots/YYYY-MM-DD_HH-MM-SS.bmp` to the SD card.
 - **Tools menu localization.** Bundled Tools entries (ADBD, Bootlogo, Clock, Files, Input, IP, Remove Loading, Toggle 560p) are shown with localized names instead of their raw `.pak` directory names.
+- **Boot logo tools.** Supported devices include a one-shot Bootlogo tool for flashing the bundled or user-supplied startup logo.
 - **ZIP data descriptor support.** MinUI's ZIP loader failed on archives that used ZIP data descriptor mode (bit flag `0x0008`), which is common for Game Boy ROM dumps produced by some tools. UnuOS detects the flag and streams inflate until `Z_STREAM_END`.
 - **Text wrap hardening.** Fixed a fixed-size buffer overflow and a NULL dereference in `GFX_wrapText()` that could be triggered by long libretro core option descriptions or long CJK strings.
 

--- a/skeleton/BASE/README.txt
+++ b/skeleton/BASE/README.txt
@@ -235,6 +235,22 @@ Simple mode
 Not simple enough for you (or maybe your kids)? UnuOS has a simple mode that hides the Tools folder and replaces Options in the in-game menu with Reset. Perfect for handing off to littles (and olds too I guess). Just create an empty file named "enable-simple-mode" (no extension) in "/.userdata/shared/".
 
 ----------------------------------------
+Bootlogo tool
+
+Some devices include a Bootlogo tool for replacing the startup logo. It is available on M17, Miyoo Mini, Miyoo A30, Miyoo Flip, Trimui Smart, Trimui Smart Pro, Trimui Brick, and MagicX Mini Zero 28.
+
+The tool flashes the bundled logo by default. On M17, Miyoo Mini, Trimui Smart, Trimui Smart Pro, Trimui Brick, and MagicX Mini Zero 28 you can replace the bundled file in the Bootlogo.pak folder before running it:
+
+  M17:                 logo.bmp
+  Miyoo Mini:          logo.jpg
+  Trimui Smart:        logo.bmp
+  Trimui Smart Pro:    tg5040/bootlogo.bmp
+  Trimui Brick:        brick/bootlogo.bmp
+  MagicX Mini Zero 28: bootlogo.bmp
+
+Miyoo A30 and Miyoo Flip use the bundled bootlogo.bmp. The Bootlogo tool changes boot storage, creates a log.txt when possible, and disables itself after running so it does not flash repeatedly. Reinstall or rename the disabled folder if you need to run it again.
+
+----------------------------------------
 Advanced
 
 UnuOS can automatically run a user-authored shell script on boot. Just place a file named "auto.sh" in "/.userdata/<DEVICE>/". If you're on Windows, make sure your text editor uses Unix line-endings (eg. `\n`), these devices usually choke on Windows line-endings (eg. `\r\n`).


### PR DESCRIPTION
## Summary
- mention Bootlogo tools in the project README additions list
- document supported Bootlogo tool devices and replaceable logo file names in the packaged README
- note that Bootlogo tools disable themselves after running

## Verification
- ran the packaged README formatting path with workspace/all/readmes makefile
- git diff --check