### PR TITLE
Prune completed todo items

### DIFF
--- a/todo.txt
+++ b/todo.txt
@@ -217,8 +217,6 @@ next
 		ldd isn't working but this is
 			LD_TRACE_LOADED_OBJECTS=1 /lib/ld-2.23.so /mnt/SDCARD/.system/my282/bin/minarch.elf
 		
-	emu pak detection isn't working when two folders are combined
-		eg. SFC and SUPA folder but no SUPA.pak still shows games from SUPA
 	all
 		look into how many cores support 8888
 			this might be a bottleneck (if it's having to go 8888 to 565 and back to 8888 for every pixel, every frame)
@@ -243,10 +241,6 @@ next
 					might be saving 1-2ms
 				could this slowness be related to vram speed? (DMC?)
 		
-		add Clear Recently Played.pak, copy to all platforms
-			maybe include confirmation?
-			requires show.elf
-		limit option name replacements based on core lib name
 		noui
 			https://gist.github.com/shauninman/20d59da8621f79ff65ad561b7ed2b6f4
 			quit doesn't work as expected on trimuismart
@@ -397,23 +391,18 @@ next
 			just system("rm /tmp/minui_exec") and exit(0) ?
 		.res
 			use standard naming (replace ext with png instead of append png)
-		better document the new Bootlogo.paks
-		
 		collections can't handle accented characters (eg. é) in path/rom name...
 			wait, why can recents.txt but not collections.txt?
 			because one is written by the device so it's using device native accented chars
 		update stored rom path logic to only require TAG and not full folder name? (would simplify Collection authoring?)
-		add make fetch to get all external sources before build?
 		add Developer.pak
 			only for devices with adb or ssh
 			
-		rewrite Shortcuts section of readme by device not the tangled mess it currently is
-			maybe do the same for all?
-			break out platforms into completely separate installers/updaters?
-				will require revisiting unzipping system
-				will need to inject not replace
-					but then how to handle removing deleted files?
-					seems like this is what currently happens on some (all?) platforms
+		break out platforms into completely separate installers/updaters?
+			will require revisiting unzipping system
+			will need to inject not replace
+				but then how to handle removing deleted files?
+				seems like this is what currently happens on some (all?) platforms
 		look into mednafen/beetle ngp core (neopop?)
 			beetle-ngp-libretro
 			this ran at about 1 frame per 10 seconds...on rgb30
@@ -504,11 +493,7 @@ known issues
 
 all
 	minarch
-		GFX_blitMessage() screen w/h is 0,0 for some reason
-		prevent MENU+button from triggering button
-		prevent binding same MENU+button to control and shortcut at same time
-			reset the newer input to None and show a message, ideal something like:
-				MENU+<button> is already bound to (<name> shortcut|<name> control)
+		show a message when MENU+button binding clears a conflicting shortcut/control
 	simple progress animation for installing/updating
 		launch as a daemon with &
 		draws in a corner
@@ -518,14 +503,10 @@ all
 		targets have too many dependencies
 		getting a little better
 	cores
-		add optional per core patch folder
-			currently looks for a global one in all/cores
 		move all the CORE_* vars up to all/cores (since they ended up all being the same)
 		there has got to be a better way to main these patches
 			updating fake-08 was so much copy/pasting
-	minui
-		alt tag is getting truncated, should be added after truncation
-	add a "res" (or "many"?) folder 
+	add a "res" (or "many"?) folder
 		for install/update and charging gfx?
 	standard
 		show


### PR DESCRIPTION
## Summary
- remove todo entries completed by recent PRs
- keep the remaining follow-up for showing a conflict message when MENU bindings are cleared

## Verification
- git diff --check