### PR TITLE
Use shallow clones for build dependencies

### DIFF
--- a/makefile.toolchain
+++ b/makefile.toolchain
@@ -20,7 +20,7 @@ $(INIT_IF_NECESSARY): $(GIT_IF_NECESSARY)
 
 $(GIT_IF_NECESSARY):
 	mkdir -p toolchains
-	git clone https://github.com/shauninman/union-$(PLATFORM)-toolchain/ toolchains/$(PLATFORM)-toolchain
+	git clone --depth 1 https://github.com/shauninman/union-$(PLATFORM)-toolchain/ toolchains/$(PLATFORM)-toolchain
 
 fetch: $(GIT_IF_NECESSARY)
 

--- a/todo.txt
+++ b/todo.txt
@@ -572,11 +572,3 @@ FIXME: main makefile is a brittle mess
 5. which builds unique platform elfs
 
 there's more to this now (eg. PLATFORM/makefile.copy)
-
----
-
-replace 
-	git clone repo && cd repo && git checkout branch 
-with
-	git clone --depth 1 --branch branch repo
-note: doesn't work with commits only branches

--- a/workspace/all/minarch/makefile
+++ b/workspace/all/minarch/makefile
@@ -54,7 +54,7 @@ clean:
 	rm -f $(PRODUCT)
 
 libretro-common:
-	git clone https://github.com/libretro/libretro-common
+	git clone --depth 1 https://github.com/libretro/libretro-common
 	
 $(PREFIX)/include/msettings.h:
 	cd /root/workspace/$(PLATFORM)/libmsettings && make

--- a/workspace/rg35xxplus/makefile
+++ b/workspace/rg35xxplus/makefile
@@ -76,12 +76,12 @@ $(REQUIRES_UNZIP60):
 	git clone --depth 1 https://github.com/shauninman/unzip60.git $(REQUIRES_UNZIP60)
 
 $(REQUIRES_SDL2):
-	git clone https://github.com/JohnnyonFlame/SDL-malifbdev-rot $(REQUIRES_SDL2)
+	git clone --depth 1 https://github.com/JohnnyonFlame/SDL-malifbdev-rot $(REQUIRES_SDL2)
 
 $(REQUIRES_DTC):
-	git clone https://github.com/dgibson/dtc $(REQUIRES_DTC)
+	git clone --depth 1 https://github.com/dgibson/dtc $(REQUIRES_DTC)
 
 $(REQUIRES_FBSET):
-	git clone https://github.com/shauninman/union-fbset $(REQUIRES_FBSET)
+	git clone --depth 1 https://github.com/shauninman/union-fbset $(REQUIRES_FBSET)
 
 include ../all/readmes/makefile


### PR DESCRIPTION
## Summary
- use shallow clones for build dependency repositories that do not need history
- remove the completed clone-depth note from todo.txt

Closes #30.

## Testing
- git diff --check
- make -n -B -f makefile.toolchain PLATFORM=rg35xxplus fetch
- make -n -B -C workspace/rg35xxplus PLATFORM=rg35xxplus fetch
- make -n -B -C workspace/all/minarch PLATFORM=rg35xxplus PREFIX=/tmp/unuos-test CC=true PRODUCT=/tmp/minarch-test CFLAGS= LDFLAGS= SOURCE=minarch.c fetch